### PR TITLE
Added a useful message to incorrect lsb indices

### DIFF
--- a/packed_struct_codegen/Cargo.toml
+++ b/packed_struct_codegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "packed_struct_codegen"
 description = "This crate implements the code generation for the packed_struct library."
 repository = "https://github.com/hashmismatch/packed_struct.rs"
-version = "0.2.3"
+version = "0.2.4"
 license = "MIT OR Apache-2.0"
 authors = ["Rudi Benkovic <rudi.benkovic@gmail.com>"]
 

--- a/packed_struct_codegen/src/pack_parse.rs
+++ b/packed_struct_codegen/src/pack_parse.rs
@@ -227,6 +227,13 @@ fn parse_field(field: &syn::Field, mp: &FieldMidPositioning, bit_range: &Range<u
 
 fn parse_reg_field(field: &syn::Field, ty: &syn::Ty, bit_range: &Range<usize>, default_endianness: Option<IntegerEndianness>) -> FieldRegular {
     let mut wrappers = vec![];
+    if bit_range.end < bit_range.start {
+        let name: ::std::borrow::Cow<str> = match field.ident {
+            Some(ref ident) => ident.to_string().into(),
+            None => "Unknown".into()
+        };
+        panic!("Field {} has a negative range. If you're using lsb, make sure to put the highest index first, e.g. 3:0 instead of 0:3", name);
+    }
 
     let bit_width = (bit_range.end - bit_range.start) + 1;
     let ty_str = syn_to_string(ty);


### PR DESCRIPTION
I had an issue where packed_struct_codegen would error with an unhelpful "attempt to subtract with overflow" error.

As it turns out, in lsb structs, I'm supposed to put the highest index first.

I added a message that made this clearer to other people using this crate.