### PR TITLE
Support for all primitive enum's backing types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Bit-level packing and unpacking for Rust
 ## Introduction
 
 Packing and unpacking bit-level structures is usually a programming tasks that needlessly reinvents the wheel. This library provides
-a meta-programming aproach, using attributes to document fields and how they should be packed. The resulting trait implementations
+a meta-programming approach, using attributes to define fields and how they should be packed. The resulting trait implementations
 provide safe packing, unpacking and runtime debugging formatters with per-field documentation generated for each structure.
 
 ## Features
@@ -29,8 +29,8 @@ provide safe packing, unpacking and runtime debugging formatters with per-field 
 
 ```toml
 [dependencies]
-packed_struct = "0.2"
-packed_struct_codegen = "0.2"
+packed_struct = "0.3"
+packed_struct_codegen = "0.3"
 ```
 ### Including the library and the code generator
 

--- a/packed_struct/Cargo.toml
+++ b/packed_struct/Cargo.toml
@@ -3,7 +3,7 @@ name = "packed_struct"
 description = "Binary-level structure packing and unpacking generator"
 repository = "https://github.com/hashmismatch/packed_struct.rs"
 homepage = "http://www.hashmismatch.net/libraries/packed-struct/"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Rudi Benkovic <rudi.benkovic@gmail.com>"]
 build = "build.rs"
 license = "MIT OR Apache-2.0"
@@ -26,4 +26,4 @@ alloc = []
 
 # comment this section when publishing new releases to crates.io!
 [dev-dependencies]
-packed_struct_codegen = "0.2"
+packed_struct_codegen = "0.3"

--- a/packed_struct/src/lib.rs
+++ b/packed_struct/src/lib.rs
@@ -8,7 +8,7 @@
 //! # Introduction
 //!
 //! Packing and unpacking bit-level structures is usually a programming tasks that needlessly reinvents the wheel. This library provides
-//! a meta-programming aproach, using attributes to document fields and how they should be packed. The resulting trait implementations
+//! a meta-programming approach, using attributes to define fields and how they should be packed. The resulting trait implementations
 //! provide safe packing, unpacking and runtime debugging formatters with per-field documentation generated for each structure.
 //!
 //! # Features
@@ -29,8 +29,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! packed_struct = "0.2"
-//! packed_struct_codegen = "0.2"
+//! packed_struct = "0.3"
+//! packed_struct_codegen = "0.3"
 //! ```
 //! ## Including the library and the code generator
 //!

--- a/packed_struct/src/primitive_enum.rs
+++ b/packed_struct/src/primitive_enum.rs
@@ -1,11 +1,14 @@
 use internal_prelude::v1::*;
 
 /// An enum type that can be packed or unpacked from a simple primitive integer.
-pub trait PrimitiveEnum<T> where T: Sized + Copy + Debug, Self: Sized + Copy {
+pub trait PrimitiveEnum where Self: Sized + Copy {
+    /// The primitve type into which we serialize and deserialize ourselves.
+    type Primitive: Sized + Copy + Debug;
+
     /// Convert from a primitive, might fail.
-    fn from_primitive(val: T) -> Option<Self>;
+    fn from_primitive(val: Self::Primitive) -> Option<Self>;
     /// Convert to a primitive value.
-    fn to_primitive(&self) -> T;
+    fn to_primitive(&self) -> Self::Primitive;
     /// Display value, same as the name of a particular variant.
     fn to_display_str(&self) -> &'static str;
     /// Convert from a string value representing the variant. Case sensitive.

--- a/packed_struct_codegen/Cargo.toml
+++ b/packed_struct_codegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "packed_struct_codegen"
 description = "This crate implements the code generation for the packed_struct library."
 repository = "https://github.com/hashmismatch/packed_struct.rs"
-version = "0.2.3"
+version = "0.3.0"
 license = "MIT OR Apache-2.0"
 authors = ["Rudi Benkovic <rudi.benkovic@gmail.com>"]
 

--- a/packed_struct_codegen/src/pack_codegen.rs
+++ b/packed_struct_codegen/src/pack_codegen.rs
@@ -361,7 +361,7 @@ fn unpack_field(field: &FieldRegular) -> quote::Tokens {
                 unpack = quote! {
                     use ::packed_struct::PrimitiveEnum;
 
-                    let primitive_integer: u8 = { #unpack };
+                    let primitive_integer: <#ty as PrimitiveEnum>::Primitive = { #unpack };
                     let r = <#ty>::from_primitive(primitive_integer).ok_or(PackingError::InvalidValue);
                     r?
                 };

--- a/packed_struct_codegen/src/pack_parse.rs
+++ b/packed_struct_codegen/src/pack_parse.rs
@@ -253,7 +253,7 @@ fn parse_reg_field(field: &syn::Field, ty: &syn::Ty, bit_range: &Range<usize>, d
 
     if needs_int_wrap {
         let ty = if is_enum_ty {
-            "u8".into()
+            format!("<{} as PrimitiveEnum>::Primitive",syn_to_string(ty))
         } else {
             ty_str.clone()
         };

--- a/packed_struct_codegen/src/primitive_enum.rs
+++ b/packed_struct_codegen/src/primitive_enum.rs
@@ -126,7 +126,9 @@ pub fn derive(ast: &syn::DeriveInput, mut prim_type: Option<syn::Ty>) -> quote::
 
         const #all_variants_const_ident: &'static [#name; #all_variants_len] = &[ #(#all_variants),* ];
 
-        impl ::packed_struct::PrimitiveEnum<#prim_type> for #name {
+        impl ::packed_struct::PrimitiveEnum for #name {
+            type Primitive = #prim_type;
+
             #[inline]
             fn from_primitive(val: #prim_type) -> Option<Self> {
                 match val {

--- a/packed_struct_examples/Cargo.toml
+++ b/packed_struct_examples/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Rudi Benkovic <rudi.benkovic@gmail.com>"]
 publish = false
 
 [dependencies]
-packed_struct = "^0.2.0"
-packed_struct_codegen = "^0.2.0"
+packed_struct = "0.3"
+packed_struct_codegen = "0.3"

--- a/packed_struct_tests/Cargo.toml
+++ b/packed_struct_tests/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Rudi Benkovic <rudi.benkovic@gmail.com>"]
 publish = false
 
 [dependencies]
-packed_struct = "^0.2.0"
-packed_struct_codegen = "^0.2.0"
+packed_struct = "0.3"
+packed_struct_codegen = "0.3"
 error-chain = "0.11.0"

--- a/packed_struct_tests/tests/packing_enum_16bit.rs
+++ b/packed_struct_tests/tests/packing_enum_16bit.rs
@@ -25,7 +25,7 @@ fn prim() {
     };
 
     let packed = st.pack();
-    assert_eq!([0b0100_0000, 0b0000_0000], packed);
+    assert_eq!([0b0000_0100, 0b0000_0000], packed);
 
     let unpacked = StructWithBitsEnum::unpack(&packed).unwrap();
     assert_eq!(st, unpacked);

--- a/packed_struct_tests/tests/packing_enum_16bit.rs
+++ b/packed_struct_tests/tests/packing_enum_16bit.rs
@@ -1,0 +1,32 @@
+extern crate packed_struct;
+#[macro_use]
+extern crate packed_struct_codegen;
+
+use packed_struct::prelude::*;
+
+#[derive(PrimitiveEnum_u16, PartialEq, Debug, Clone, Copy)]
+pub enum LargeEnum {
+    Value1 = 1,
+    Value1024 = 1024,
+    Value4096 = 4096
+}
+
+#[derive(PackedStruct, PartialEq, Debug, Clone, Copy)]
+#[packed_struct(size_bytes="2", bit_numbering="msb0", endian="msb")]
+pub struct StructWithBitsEnum {
+    #[packed_field(bits="0..16", ty="enum")]
+    large: LargeEnum
+}
+
+#[test]
+fn prim() {
+    let st = StructWithBitsEnum {
+        large: LargeEnum::Value1024
+    };
+
+    let packed = st.pack();
+    assert_eq!([0b0100_0000, 0b0000_0000], packed);
+
+    let unpacked = StructWithBitsEnum::unpack(&packed).unwrap();
+    assert_eq!(st, unpacked);
+}


### PR DESCRIPTION
Change the `PrimitiveEnum` so that it uses an associated type for the backing field type. This way we can extract the intermediate type being used during packing or unpacking.

I would consider this a breaking change, so it should be released as version `0.3.0`.

Closes #27 