### PR TITLE
Support either order for a field's range bit position

### DIFF
--- a/packed_struct_codegen/src/pack_parse.rs
+++ b/packed_struct_codegen/src/pack_parse.rs
@@ -318,6 +318,10 @@ impl BitsPositionParsed {
             BitsPositionParsed::Range(a, b) => Box::new(a..b)
         }
     }
+
+    pub fn range_in_order(a: usize, b: usize) -> Self {
+        BitsPositionParsed::Range(::std::cmp::min(a, b), ::std::cmp::max(a, b))
+    }
 }
 
 
@@ -390,7 +394,7 @@ pub fn parse_struct(ast: &syn::MacroInput) -> PackStruct {
                 },
                 (Some(BitNumbering::Lsb0), BitsPositionParsed::Range(start, end)) => {
                     if let Some(struct_size_bytes) = struct_size_bytes {
-                        BitsPositionParsed::Range( (struct_size_bytes * 8) - 1 - start, (struct_size_bytes * 8) - 1 - end )
+                        BitsPositionParsed::range_in_order( (struct_size_bytes * 8) - 1 - start, (struct_size_bytes * 8) - 1 - end )
                     } else {
                         panic!("LSB0 field positioning currently requires explicit struct byte size.");
                     }

--- a/packed_struct_codegen/src/pack_parse_attributes.rs
+++ b/packed_struct_codegen/src/pack_parse_attributes.rs
@@ -207,9 +207,9 @@ pub fn parse_position_val(v: &str, multiplier: usize) -> BitsPositionParsed {
             let start = parse_num(s[0]);
             let end = parse_num(s[1]);
             if multiplier > 1 {
-                return BitsPositionParsed::Range(start * multiplier, ((end+1) * multiplier)-1);
+                return BitsPositionParsed::range_in_order(start * multiplier, ((end+1) * multiplier)-1);
             } else {
-                return BitsPositionParsed::Range(start, end);
+                return BitsPositionParsed::range_in_order(start, end);
             }
         }
 
@@ -225,9 +225,9 @@ pub fn parse_position_val(v: &str, multiplier: usize) -> BitsPositionParsed {
             }
             
             if multiplier > 1 {
-                return BitsPositionParsed::Range(start * multiplier, ((end-1) * multiplier)-1);
+                return BitsPositionParsed::range_in_order(start * multiplier, ((end-1) * multiplier)-1);
             } else {
-                return BitsPositionParsed::Range(start, end - 1);
+                return BitsPositionParsed::range_in_order(start, end - 1);
             }
         }
     } else {

--- a/packed_struct_tests/tests/packing_lsb_bit_order.rs
+++ b/packed_struct_tests/tests/packing_lsb_bit_order.rs
@@ -1,0 +1,29 @@
+extern crate packed_struct;
+#[macro_use]
+extern crate packed_struct_codegen;
+
+use packed_struct::prelude::*;
+
+// both orders (high-low, low-high) should be supported!
+
+#[derive(PackedStruct, Copy, Clone, Debug, PartialEq)]
+#[packed_struct(size_bytes="1", bit_numbering="lsb0")]
+pub struct IntsLsbPosBits {
+    #[packed_field(bits="0:3")]
+    num1: Integer<u8, packed_bits::Bits4>,
+    #[packed_field(bits="7:4")]
+    num2: Integer<u8, packed_bits::Bits4>    
+}
+
+#[test]
+fn test_pos() {
+    let s = IntsLsbPosBits {
+        num1: 9.into(),
+        num2: 28.into()
+    };
+
+    let packed = s.pack();
+    let unpacked = IntsLsbPosBits::unpack(&packed).unwrap();
+
+    assert_eq!(unpacked, s);
+}


### PR DESCRIPTION
A more user-friendly implementation of #28. As, after all, we are extremely lazy developers.