### PR TITLE
Broken big ints

### DIFF
--- a/packed_struct_tests/tests/packing_bit_positioning.rs
+++ b/packed_struct_tests/tests/packing_bit_positioning.rs
@@ -60,6 +60,32 @@ fn test_packing_bit_positions_lsb() {
 }
 
 
+#[derive(PackedStruct, PartialEq, Debug)]
+#[packed_struct(size_bytes="4", bit_numbering="lsb0", endian="lsb")]
+pub struct BigIntsLsb {
+    #[packed_field(bits="2:0")]
+    pub val1: Integer<u8, packed_bits::Bits3>,
+    #[packed_field(bits="6")]
+    pub val2: bool,
+    #[packed_field(bits="31:16")]
+    pub val3: Integer<u16, packed_bits::Bits16>,
+}
+
+#[test]
+fn test_packing_bit_positions_bigints_lsb() {
+    let a = BigIntsLsb {
+        val1: 7.into(),
+        val2: true,
+        val3: 0xbeef.into(),
+    };
+
+    let packed = a.pack();
+    assert_eq!(&[0x07u8, 0x04, 0xef, 0xbe], &packed);
+
+    let unpacked = BigIntsLsb::unpack(&packed).unwrap();
+    assert_eq!(a, unpacked);
+}
+
 
 #[test]
 fn test_packing_byte_position() {

--- a/packed_struct_tests/tests/packing_bit_positioning.rs
+++ b/packed_struct_tests/tests/packing_bit_positioning.rs
@@ -63,15 +63,16 @@ fn test_packing_bit_positions_lsb() {
 #[derive(PackedStruct, PartialEq, Debug)]
 #[packed_struct(size_bytes="4", bit_numbering="lsb0", endian="lsb")]
 pub struct BigIntsLsb {
-    #[packed_field(bits="2:0")]
+    #[packed_field(bits="26:24")]
     pub val1: Integer<u8, packed_bits::Bits3>,
-    #[packed_field(bits="6")]
+    #[packed_field(bits="18")]
     pub val2: bool,
-    #[packed_field(bits="31:16")]
+    #[packed_field(bits="15:0")]
     pub val3: Integer<u16, packed_bits::Bits16>,
 }
 
 #[test]
+/// This test should verify the packing/unpacking a hypothetical 32-bit register that contains 0xbeef0407
 fn test_packing_bit_positions_bigints_lsb() {
     let a = BigIntsLsb {
         val1: 7.into(),
@@ -80,7 +81,7 @@ fn test_packing_bit_positions_bigints_lsb() {
     };
 
     let packed = a.pack();
-    assert_eq!(&[0x07u8, 0x04, 0xef, 0xbe], &packed);
+    assert_eq!(&[0x07u8, 0x04, 0xef, 0xbe], &packed, "mismatch received: {}", a);
 
     let unpacked = BigIntsLsb::unpack(&packed).unwrap();
     assert_eq!(a, unpacked);


### PR DESCRIPTION
I have updated the test case so that it demonstrates the bit indexing for multi item structures. This is in line with my latest comment to https://github.com/hashmismatch/packed_struct.rs/issues/35

