### PR TITLE
unpack_from_slice: Make sure slices contain at least the amount of bytes

### DIFF
--- a/packed_struct/src/packing.rs
+++ b/packed_struct/src/packing.rs
@@ -86,11 +86,11 @@ macro_rules! packing_slice {
 
             #[inline]
             fn unpack_from_slice(src: &[u8]) -> Result<Self, PackingError> {
-                if src.len() != $num_bytes {
+                if src.len() < $num_bytes {
                     return Err(PackingError::BufferTooSmall);
                 }
                 let mut s = [0; $num_bytes];
-                &mut s[..].copy_from_slice(src);
+                &mut s[..].copy_from_slice(&src[..$num_bytes]);
                 Self::unpack(&s)
             }
 

--- a/packed_struct/src/types_num.rs
+++ b/packed_struct/src/types_num.rs
@@ -577,7 +577,7 @@ impl<T, B, I> PackedStructSlice for MsbInteger<T, B, I> where B: NumberOfBits, I
 
     fn unpack_from_slice(src: &[u8]) -> Result<Self, PackingError> {
         let expected_bytes = <B as NumberOfBits>::Bytes::number_of_bytes() as usize;
-        if src.len() != expected_bytes {
+        if src.len() < expected_bytes {
             return Err(PackingError::BufferSizeMismatch { expected: expected_bytes, actual: src.len() });
         }
         let mut s = Default::default();
@@ -585,7 +585,7 @@ impl<T, B, I> PackedStructSlice for MsbInteger<T, B, I> where B: NumberOfBits, I
         {
             Self::unpack(&s)?;
         }
-        s.as_mut_bytes_slice().copy_from_slice(src);
+        s.as_mut_bytes_slice().copy_from_slice(&src[..expected_bytes]);
         Self::unpack(&s)
     }
 
@@ -657,7 +657,7 @@ impl<T, B, I> PackedStructSlice for LsbInteger<T, B, I> where B: NumberOfBits + 
 
     fn unpack_from_slice(src: &[u8]) -> Result<Self, PackingError> {
         let expected_bytes = <B as NumberOfBits>::Bytes::number_of_bytes() as usize;
-        if src.len() != expected_bytes {
+        if src.len() < expected_bytes {
             return Err(PackingError::BufferSizeMismatch { expected: expected_bytes, actual: src.len() });
         }
         let mut s = Default::default();
@@ -665,7 +665,7 @@ impl<T, B, I> PackedStructSlice for LsbInteger<T, B, I> where B: NumberOfBits + 
         {
             Self::unpack(&s)?;
         }
-        s.as_mut_bytes_slice().copy_from_slice(src);
+        s.as_mut_bytes_slice().copy_from_slice(&src[..expected_bytes]);
         Self::unpack(&s)
     }
 

--- a/packed_struct/src/types_num.rs
+++ b/packed_struct/src/types_num.rs
@@ -737,3 +737,10 @@ fn test_packed_int_lsb_sub() {
     let packed = endian.pack();
     assert_eq!([0xCC, 0xBB, 0xAA], packed);
 }
+
+#[test]
+fn test_big_slice_unpacking() {
+    let data = vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE];
+    let unpacked = <MsbInteger<_, _, Integer<u32, Bits32>>>::unpack_from_slice(&data).unwrap();
+    assert_eq!(0xAABBCCDD, **unpacked);
+}

--- a/packed_struct_codegen/src/pack_codegen.rs
+++ b/packed_struct_codegen/src/pack_codegen.rs
@@ -157,11 +157,11 @@ pub fn derive_pack(parsed: &PackStruct) -> quote::Tokens {
             fn unpack_from_slice(src: &[u8]) -> #result_ty <Self, ::packed_struct::PackingError> {
                 use ::packed_struct::*;
 
-                if src.len() != #num_bytes {
+                if src.len() < #num_bytes {
                     return Err(::packed_struct::PackingError::BufferTooSmall);
                 }
                 let mut s = [0; #num_bytes];
-                &mut s[..].copy_from_slice(src);
+                &mut s[..].copy_from_slice(&src[..#num_bytes]);
                 Self::unpack(&s)
             }
 

--- a/packed_struct_tests/tests/packing_codegen_3.rs
+++ b/packed_struct_tests/tests/packing_codegen_3.rs
@@ -1,0 +1,41 @@
+extern crate packed_struct;
+#[macro_use]
+extern crate packed_struct_codegen;
+
+use packed_struct::prelude::*;
+
+#[derive(PackedStruct)]
+#[packed_struct(endian = "msb", size_bytes = "7")]
+pub struct TestStructBE {
+    a: u8,
+    b: u32,
+    c: u16,
+}
+
+#[derive(PackedStruct)]
+#[packed_struct(endian = "lsb", size_bytes = "7")]
+pub struct TestStructLE {
+    a: u8,
+    b: u32,
+    c: u16,
+}
+
+#[test]
+#[cfg(test)]
+fn test_struct_be_unpack() {
+    let buf = &[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+    let unpacked: TestStructBE = TestStructBE::unpack_from_slice(buf).unwrap();
+    assert_eq!(unpacked.a, 0x11);
+    assert_eq!(unpacked.b, 0x22334455);
+    assert_eq!(unpacked.c, 0x6677);
+}
+
+#[test]
+#[cfg(test)]
+fn test_struct_le_unpack() {
+    let buf = &[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+    let unpacked: TestStructLE = TestStructLE::unpack_from_slice(buf).unwrap();
+    assert_eq!(unpacked.a, 0x11);
+    assert_eq!(unpacked.b, 0x55443322);
+    assert_eq!(unpacked.c, 0x7766);
+}


### PR DESCRIPTION
Instead of performing an exact comparison, make sure that the slice is at least as big as the expected size.
This saves boiler plate code for the caller.