### PR TITLE
Cross platform CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [aarch64-unknown-linux-gnu, mips64-unknown-linux-gnuabi64, riscv64gc-unknown-linux-gnu ]
+        target: [aarch64-unknown-linux-gnu, arm-unknown-linux-gnueabihf, mips64-unknown-linux-gnuabi64, riscv64gc-unknown-linux-gnu ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,11 +25,15 @@ jobs:
   build-cross:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        target: [aarch64-unknown-linux-gnu, mips64-unknown-linux-gnuabi64, riscv64gc-unknown-linux-gnu, wasm32-unknown-emscripten ]
+
     steps:
     - uses: actions/checkout@v2
-    - name: Install cross
+    - name: Install rust-embedded/cross
       run: cargo install cross
-    - name: Build
-      run: cross build --target aarch64-unknown-linux-gnu
-    - name: Run tests
-      run: cross test --target aarch64-unknown-linux-gnu
+    - name: Cross-build
+      run: cross build --target ${{ matrix.target }}
+    - name: Cross-run tests
+      run: cross test --target ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -22,3 +21,15 @@ jobs:
       run: cargo test --verbose
     - name: Rust no_std tests
       run: cd packed_struct_nostd_tests && cargo test --verbose
+  
+  build-cross:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install cross
+      run: cargo install cross
+    - name: Build
+      run: cross build --target aarch64-unknown-linux-gnu
+    - name: Run tests
+      run: cross test --target aarch64-unknown-linux-gnu

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,8 +26,9 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        target: [aarch64-unknown-linux-gnu, mips64-unknown-linux-gnuabi64, riscv64gc-unknown-linux-gnu, wasm32-unknown-emscripten ]
+        target: [aarch64-unknown-linux-gnu, mips64-unknown-linux-gnuabi64, riscv64gc-unknown-linux-gnu ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Uses https://github.com/rust-embedded/cross

Added a Big Endian target (MIPS64) and a 32-bit target (arm-unknown). Those two platforms fail with known issues that will be fixed later.