### PR TITLE
Fixes for other platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Bit-level packing and unpacking for Rust
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation](https://docs.rs/packed_struct/badge.svg)](https://docs.rs/packed_struct)
+![Rust](https://github.com/hashmismatch/packed_struct.rs/workflows/Rust/badge.svg)
 
 [crates-badge]: https://img.shields.io/crates/v/packed_struct.svg
 [crates-url]: https://crates.io/crates/packed_struct

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Bit-level packing and unpacking for Rust
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation](https://docs.rs/packed_struct/badge.svg)](https://docs.rs/packed_struct)
-![Rust](https://github.com/hashmismatch/packed_struct.rs/workflows/Rust/badge.svg)
+![master](https://github.com/hashmismatch/packed_struct.rs/workflows/Rust/badge.svg)
 
 [crates-badge]: https://img.shields.io/crates/v/packed_struct.svg
 [crates-url]: https://crates.io/crates/packed_struct

--- a/packed_struct/src/types_num.rs
+++ b/packed_struct/src/types_num.rs
@@ -164,13 +164,12 @@ macro_rules! integer_as_bytes {
 
             #[inline]
             fn to_msb_bytes(&self) -> [u8; $N] {
-                let n = self.to_le();
-                as_bytes!($N, n)
+                as_bytes!($N, self)
             }
 
             #[inline]
             fn to_lsb_bytes(&self) -> [u8; $N] {
-                let n = self.to_be();
+                let n = self.swap_bytes();
                 as_bytes!($N, n)
             }
             
@@ -182,7 +181,7 @@ macro_rules! integer_as_bytes {
             #[inline]
             fn from_lsb_bytes(bytes: &[u8; $N]) -> Self {
                 let n = from_bytes!($N, bytes, $T);
-                n.to_be()
+                n.swap_bytes()
             }
         }
     };

--- a/packed_struct_tests/tests/primitive_enum_types.rs
+++ b/packed_struct_tests/tests/primitive_enum_types.rs
@@ -16,6 +16,7 @@ pub enum EnumU16 {
     VariantMax = 65535
 }
 
+#[repr(u32)]
 #[derive(PrimitiveEnum, PartialEq, Debug, Clone, Copy)]
 pub enum EnumU32 {
     VariantMin = 0,


### PR DESCRIPTION
Fixed integers on big-endian machines, untested on real hardware.
Fix for tests on 32-bit platforms.
Added the CI badge to the readme file.

Fixes #48