### PR TITLE
Slice indexing should be error checked

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,7 @@ jobs:
   
   build-cross:
     runs-on: ubuntu-latest
+    needs: [build]
 
     strategy:
       fail-fast: false

--- a/packed_struct/build.rs
+++ b/packed_struct/build.rs
@@ -6,6 +6,8 @@ use std::io::Write;
 use std::path::Path;
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("generate_bytes_and_bits.rs");
     let mut f = File::create(&dest_path).unwrap();

--- a/packed_struct/src/debug_fmt.rs
+++ b/packed_struct/src/debug_fmt.rs
@@ -107,7 +107,12 @@ use crate::types_bits::ByteArray;
 
 impl<'a, P> fmt::Display for PackedStructDisplay<'a, P> where P: PackedStruct + PackedStructDebug {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let packed = self.packed_struct.pack();
+        let packed = match self.packed_struct.pack() {
+            Ok(packed) => packed,
+            Err(e) => {
+                return f.write_fmt(format_args!("Error while packing: {:?}", e));                
+            }
+        };
         let packed = packed.as_bytes_slice();
         let l = packed.len();
 

--- a/packed_struct/src/lib.rs
+++ b/packed_struct/src/lib.rs
@@ -278,8 +278,6 @@
 //! # fn main() {}
 //! ```
 
-#![deny(clippy::indexing_slicing)]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![cfg_attr(feature="alloc", feature(alloc))]

--- a/packed_struct/src/lib.rs
+++ b/packed_struct/src/lib.rs
@@ -278,6 +278,8 @@
 //! # fn main() {}
 //! ```
 
+#![deny(clippy::indexing_slicing)]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![cfg_attr(feature="alloc", feature(alloc))]

--- a/packed_struct/src/lib.rs
+++ b/packed_struct/src/lib.rs
@@ -76,7 +76,7 @@
 //!         enabled: true
 //!     };
 //!
-//!     let packed = test.pack();
+//!     let packed = test.pack().unwrap();
 //!     assert_eq!([0b10111001], packed);
 //!
 //!     let unpacked = TestPack::unpack(&packed).unwrap();
@@ -160,7 +160,7 @@
 //!         int2: 0x11223344
 //!     };
 //!
-//!     let packed = example.pack();
+//!     let packed = example.pack().unwrap();
 //!     assert_eq!([0xAA, 0xBB, 0x11, 0x22, 0x33, 0x44], packed);
 //! }
 //! ```
@@ -184,7 +184,7 @@
 //!         int1: 0xCCBBAA.into()
 //!     };
 //!
-//!     let packed = example.pack();
+//!     let packed = example.pack().unwrap();
 //!     assert_eq!([0xAA, 0xBB, 0xCC], packed);
 //! }
 //! ```
@@ -222,7 +222,7 @@
 //!         ]
 //!     };
 //!
-//!     let packed = example.pack();
+//!     let packed = example.pack().unwrap();
 //!     let unpacked = Settings::unpack(&packed).unwrap();
 //!
 //!     assert_eq!(example, unpacked);

--- a/packed_struct/src/packing.rs
+++ b/packed_struct/src/packing.rs
@@ -80,4 +80,10 @@ impl ::std::error::Error for PackingError {
     }
 }
 
+impl From<PackingError> for fmt::Error {
+    fn from(_: PackingError) -> Self {
+        Self
+    }
+}
+
 pub type PackingResult<T> = Result<T, PackingError>;

--- a/packed_struct/src/packing.rs
+++ b/packed_struct/src/packing.rs
@@ -12,9 +12,9 @@ use crate::types_bits::ByteArray;
 pub trait PackedStruct where Self: Sized {
     type ByteArray : ByteArray;
     /// Packs the structure into a byte array.
-    fn pack(&self) -> Self::ByteArray;
+    fn pack(&self) -> PackingResult<Self::ByteArray>;
     /// Unpacks the structure from a byte array.
-    fn unpack(src: &Self::ByteArray) -> Result<Self, PackingError>;
+    fn unpack(src: &Self::ByteArray) -> PackingResult<Self>;
 }
 
 /// Infos about a particular type that can be packaged.
@@ -26,14 +26,14 @@ pub trait PackedStructInfo {
 /// A structure that can be packed and unpacked from a slice of bytes.
 pub trait PackedStructSlice where Self: Sized {
     /// Pack the structure into an output buffer.
-    fn pack_to_slice(&self, output: &mut [u8]) -> Result<(), PackingError>;
+    fn pack_to_slice(&self, output: &mut [u8]) -> PackingResult<()>;
     /// Unpack the structure from a buffer.
-    fn unpack_from_slice(src: &[u8]) -> Result<Self, PackingError>;
+    fn unpack_from_slice(src: &[u8]) -> PackingResult<Self>;
     /// Number of bytes that the type or this particular instance of this structure demands for packing or unpacking.
-    fn packed_bytes_size(opt_self: Option<&Self>) -> Result<usize, PackingError>;
+    fn packed_bytes_size(opt_self: Option<&Self>) -> PackingResult<usize>;
 
     #[cfg(any(feature="alloc", feature="std"))]
-    fn pack_to_vec(&self) -> Result<Vec<u8>, PackingError> {
+    fn pack_to_vec(&self) -> PackingResult<Vec<u8>> {
         let size = Self::packed_bytes_size(Some(self))?;
         let mut buf = vec![0; size];
         self.pack_to_slice(&mut buf)?;
@@ -79,3 +79,5 @@ impl ::std::error::Error for PackingError {
         }
     }
 }
+
+pub type PackingResult<T> = Result<T, PackingError>;

--- a/packed_struct/src/types_array.rs
+++ b/packed_struct/src/types_array.rs
@@ -7,8 +7,8 @@ macro_rules! packable_u8_array {
             type ByteArray = [u8; $N];
 
             #[inline]
-            fn pack(&self) -> Self::ByteArray {
-                *self
+            fn pack(&self) -> PackingResult<Self::ByteArray> {
+                Ok(*self)
             }
 
             #[inline]

--- a/packed_struct/src/types_basic.rs
+++ b/packed_struct/src/types_basic.rs
@@ -4,8 +4,8 @@ impl PackedStruct for bool {
     type ByteArray = [u8; 1];
 
     #[inline]
-    fn pack(&self) -> [u8; 1] {
-        if *self { [1] } else { [0] }
+    fn pack(&self) -> PackingResult<[u8; 1]> {
+        Ok(if *self { [1] } else { [0] })
     }
 
     #[inline]
@@ -30,8 +30,8 @@ impl PackedStruct for u8 {
     type ByteArray = [u8; 1];
 
     #[inline]
-    fn pack(&self) -> [u8; 1] {
-        [*self]
+    fn pack(&self) -> PackingResult<[u8; 1]> {
+        Ok([*self])
     }
 
     #[inline]
@@ -52,8 +52,8 @@ impl PackedStruct for i8 {
     type ByteArray = [u8; 1];
 
     #[inline]
-    fn pack(&self) -> Self::ByteArray {
-        [*self as u8]
+    fn pack(&self) -> PackingResult<Self::ByteArray> {
+        Ok([*self as u8])
     }
 
     #[inline]
@@ -74,8 +74,8 @@ impl PackedStruct for () {
     type ByteArray = [u8; 0];
 
     #[inline]
-    fn pack(&self) -> [u8; 0] {
-        []
+    fn pack(&self) -> PackingResult<[u8; 0]> {
+        Ok([])
     }
 
     #[inline]

--- a/packed_struct/src/types_generic.rs
+++ b/packed_struct/src/types_generic.rs
@@ -6,7 +6,7 @@ impl<T> PackedStructSlice for T where T: PackedStruct, T::ByteArray : ByteArray 
         if output.len() != <T::ByteArray as ByteArray>::len() {
             return Err(PackingError::BufferSizeMismatch { expected: <T::ByteArray as ByteArray>::len(), actual: output.len() });
         }
-        let packed = self.pack();                
+        let packed = self.pack()?;
         &mut output[..].copy_from_slice(&packed.as_bytes_slice());
         Ok(())
     }

--- a/packed_struct/src/types_num.rs
+++ b/packed_struct/src/types_num.rs
@@ -251,7 +251,7 @@ macro_rules! integer_bytes_impl {
                 }
                 let skip = native_bytes.len() - bytes.len();
                 {
-                    let native_bytes = &mut native_bytes[skip..];
+                    let native_bytes = lib_get_mut_slice(&mut native_bytes, skip..)?;
                     native_bytes.copy_from_slice(&bytes[..]);
                 }
                 let v = <$T>::from_msb_bytes(&native_bytes);
@@ -269,7 +269,7 @@ macro_rules! integer_bytes_impl {
 
                 {
                     let take = bytes.len();
-                    let native_bytes = &mut native_bytes[..take];
+                    let native_bytes = lib_get_mut_slice(&mut native_bytes, ..take)?;
                     native_bytes.copy_from_slice(&bytes[..]);
                 }
 

--- a/packed_struct/src/types_num.rs
+++ b/packed_struct/src/types_num.rs
@@ -453,8 +453,8 @@ fn test_u16() {
     let val = 0xABCD;
     let num: Integer<u16, Bits16> = val.into();
     assert_eq!(val, *num);
-    assert_eq!([0xAB, 0xCD], num.to_msb_bytes());
-    assert_eq!([0xCD, 0xAB], num.to_lsb_bytes());
+    assert_eq!([0xAB, 0xCD], num.to_msb_bytes().unwrap());
+    assert_eq!([0xCD, 0xAB], num.to_lsb_bytes().unwrap());
 }
 
 #[test]
@@ -462,8 +462,8 @@ fn test_u32() {
     let val = 0x4589ABCD;
     let num: Integer<u32, Bits32> = val.into();
     assert_eq!(val, *num);
-    assert_eq!([0x45, 0x89, 0xAB, 0xCD], num.to_msb_bytes());
-    assert_eq!([0xCD, 0xAB, 0x89, 0x45], num.to_lsb_bytes());
+    assert_eq!([0x45, 0x89, 0xAB, 0xCD], num.to_msb_bytes().unwrap());
+    assert_eq!([0xCD, 0xAB, 0x89, 0x45], num.to_lsb_bytes().unwrap());
 }
 
 #[test]
@@ -471,19 +471,19 @@ fn test_u64() {
     let val = 0x1122334455667788;
     let num: Integer<u64, Bits64> = val.into();
     assert_eq!(val, *num);
-    assert_eq!([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88], num.to_msb_bytes());
-    assert_eq!([0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11], num.to_lsb_bytes());
+    assert_eq!([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88], num.to_msb_bytes().unwrap());
+    assert_eq!([0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11], num.to_lsb_bytes().unwrap());
 }
 
 #[test]
 fn test_roundtrip_u32() {
     let val = 0x11223344;
     let num: Integer<u32, Bits32> = val.into();
-    let msb_bytes = num.to_msb_bytes();
+    let msb_bytes = num.to_msb_bytes().unwrap();
     let from_msb = u32::from_msb_bytes(&msb_bytes);
     assert_eq!(val, from_msb);
 
-    let lsb_bytes = num.to_lsb_bytes();
+    let lsb_bytes = num.to_lsb_bytes().unwrap();
     let from_lsb = u32::from_lsb_bytes(&lsb_bytes);
     assert_eq!(val, from_lsb);
 }
@@ -492,14 +492,14 @@ fn test_roundtrip_u32() {
 fn test_roundtrip_u24() {
     let val = 0xCCBBAA;
     let num: Integer<u32, Bits24> = val.into();
-    let msb_bytes = num.to_msb_bytes();
+    let msb_bytes = num.to_msb_bytes().unwrap();
     assert_eq!([0xCC, 0xBB, 0xAA], msb_bytes);
-    let from_msb = <Integer<u32, Bits24>>::from_msb_bytes(&msb_bytes);
+    let from_msb = <Integer<u32, Bits24>>::from_msb_bytes(&msb_bytes).unwrap();
     assert_eq!(val, *from_msb);
 
-    let lsb_bytes = num.to_lsb_bytes();
+    let lsb_bytes = num.to_lsb_bytes().unwrap();
     assert_eq!([0xAA, 0xBB, 0xCC], lsb_bytes);
-    let from_lsb = <Integer<u32, Bits24>>::from_lsb_bytes(&lsb_bytes);
+    let from_lsb = <Integer<u32, Bits24>>::from_lsb_bytes(&lsb_bytes).unwrap();
     assert_eq!(val, *from_lsb);
 }
 
@@ -507,9 +507,9 @@ fn test_roundtrip_u24() {
 fn test_roundtrip_u20() {
     let val = 0xFBBAA;
     let num: Integer<u32, Bits20> = val.into();
-    let msb_bytes = num.to_msb_bytes();
+    let msb_bytes = num.to_msb_bytes().unwrap();
     assert_eq!([0x0F, 0xBB, 0xAA], msb_bytes);
-    let from_msb = <Integer<u32, Bits20>>::from_msb_bytes(&msb_bytes);
+    let from_msb = <Integer<u32, Bits20>>::from_msb_bytes(&msb_bytes).unwrap();
     assert_eq!(val, *from_msb);    
 }
 
@@ -627,7 +627,7 @@ fn test_packed_int_msb() {
     let val = 0xAABBCCDD;
     let typed: Integer<u32, Bits32> = val.into();
     let endian = typed.as_packed_msb();
-    let packed = endian.pack();
+    let packed = endian.pack().unwrap();
     assert_eq!([0xAA, 0xBB, 0xCC, 0xDD], packed);
     
     let unpacked: MsbInteger<_, _, Integer<u32, Bits32>> = MsbInteger::unpack(&packed).unwrap();
@@ -639,7 +639,7 @@ fn test_packed_int_partial() {
     let val = 0b10_10101010;
     let typed: Integer<u16, Bits10> = val.into();
     let endian = typed.as_packed_msb();
-    let packed = endian.pack();
+    let packed = endian.pack().unwrap();
     assert_eq!([0b00000010, 0b10101010], packed);
     
     let unpacked: MsbInteger<_, _, Integer<u16, Bits10>> = MsbInteger::unpack(&packed).unwrap();
@@ -651,7 +651,7 @@ fn test_packed_int_lsb() {
     let val = 0xAABBCCDD;
     let typed: Integer<u32, Bits32> = val.into();
     let endian = typed.as_packed_lsb();
-    let packed = endian.pack();
+    let packed = endian.pack().unwrap();
     assert_eq!([0xDD, 0xCC, 0xBB, 0xAA], packed);
     
     let unpacked: LsbInteger<_, _, Integer<u32, Bits32>> = LsbInteger::unpack(&packed).unwrap();
@@ -684,7 +684,7 @@ fn test_packed_int_lsb_sub() {
     let val = 0xAABBCC;
     let typed: Integer<u32, Bits24> = val.into();
     let endian = typed.as_packed_lsb();
-    let packed = endian.pack();
+    let packed = endian.pack().unwrap();
     assert_eq!([0xCC, 0xBB, 0xAA], packed);
 }
 

--- a/packed_struct/src/types_reserved.rs
+++ b/packed_struct/src/types_reserved.rs
@@ -68,8 +68,8 @@ use types_bits::{NumberOfBits, NumberOfBytes, ByteArray};
 
 impl<V, B> PackedStruct for ReservedBits<V, B> where Self: Default, V: ReservedBitValue, B: NumberOfBits {
     type ByteArray = <<B as NumberOfBits>::Bytes as NumberOfBytes>::AsBytes;
-    fn pack(&self) -> <<B as NumberOfBits>::Bytes as NumberOfBytes>::AsBytes {
-        <<<B as NumberOfBits>::Bytes as NumberOfBytes>::AsBytes>::new(V::get_reserved_bit_value_byte())
+    fn pack(&self) -> PackingResult<<<B as NumberOfBits>::Bytes as NumberOfBytes>::AsBytes> {
+        Ok(<<<B as NumberOfBits>::Bytes as NumberOfBytes>::AsBytes>::new(V::get_reserved_bit_value_byte()))
     }
 
     fn unpack(_src: &<<B as NumberOfBits>::Bytes as NumberOfBytes>::AsBytes) -> Result<Self, PackingError> {

--- a/packed_struct/src/types_vec.rs
+++ b/packed_struct/src/types_vec.rs
@@ -2,7 +2,7 @@
 
 use internal_prelude::v1::*;
 
-use crate::{PackedStructSlice, PackingError};
+use crate::{PackedStructSlice, PackingError, lib_get_mut_slice, lib_get_slice};
 
 /// This can only be used as a vector of structures that have a statically known size
 impl<T> PackedStructSlice for Vec<T> where T: PackedStructSlice {
@@ -15,7 +15,8 @@ impl<T> PackedStructSlice for Vec<T> where T: PackedStructSlice {
         let size = T::packed_bytes_size(None)?;
 
         for (i, item) in self.iter().enumerate() {
-            item.pack_to_slice(&mut output[(i * size)..((i+1)*size)])?;
+            let mut item_out = lib_get_mut_slice(output, (i * size)..((i+1)*size))?;
+            item.pack_to_slice(item_out)?;
         }
 
         Ok(())
@@ -32,7 +33,8 @@ impl<T> PackedStructSlice for Vec<T> where T: PackedStructSlice {
 
         let mut vec = Vec::with_capacity(n);
         for i in 0..n {
-            let item = T::unpack_from_slice(&src[(i*item_size)..((i+1)*item_size)])?;
+            let item_src = lib_get_slice(src, (i*item_size)..((i+1)*item_size))?;
+            let item = T::unpack_from_slice(item_src)?;
             vec.push(item);
         }        
 

--- a/packed_struct_codegen/src/pack_codegen.rs
+++ b/packed_struct_codegen/src/pack_codegen.rs
@@ -110,14 +110,14 @@ pub fn derive_pack(parsed: &PackStruct) -> quote::Tokens {
 
             #[inline]
             #[allow(unused_imports, unused_parens)]
-            fn pack(&self) -> Self::ByteArray {
+            fn pack(&self) -> ::packed_struct::PackingResult<Self::ByteArray> {
                 use ::packed_struct::*;
 
                 let mut target = [0 as u8; #num_bytes];
 
                 #(#pack_fields)*
 
-                target
+                Ok(target)
             }
 
             #[inline]
@@ -297,7 +297,7 @@ fn pack_field(name: &syn::Ident, field: &FieldRegular) -> quote::Tokens {
 
     quote! {
         {
-            { & #output }.pack()
+            { & #output }.pack()?
         }
     }
 }
@@ -318,7 +318,7 @@ fn unpack_field(field: &FieldRegular) -> quote::Tokens {
                     use ::packed_struct::types::bits::*;
 
                     let res: #result_ty <#endian <_, _, #integer >, PackingError> = <#endian <_, _, _>>::unpack(& #unpack );
-                    let unpacked = try!(res);
+                    let unpacked = res?;
                     **unpacked
                 };
 

--- a/packed_struct_codegen/src/pack_codegen_docs.rs
+++ b/packed_struct_codegen/src/pack_codegen_docs.rs
@@ -71,7 +71,7 @@ pub fn struct_runtime_formatter(parsed: &PackStruct) -> quote::Tokens {
                 use ::packed_struct::PackedStruct;
                 
                 let fields = #debug_fields_fn(self);
-                let packed: [u8; #num_bytes] = self.pack();
+                let packed: [u8; #num_bytes] = self.pack()?;
                 ::packed_struct::debug_fmt::packable_fmt_fields(fmt, &packed, &fields)
             }
 

--- a/packed_struct_examples/src/example1.rs
+++ b/packed_struct_examples/src/example1.rs
@@ -49,7 +49,7 @@ fn test_display() {
         sensor_value: -1503
     };
 
-    let packed: [u8; 4] = reg.pack();
+    let packed: [u8; 4] = reg.pack().unwrap();
     let unpacked = ControlRegister::unpack(&[0x8B, 0xE7, 0x21, 0xFA]).unwrap();
 
     println!("{}", reg);

--- a/packed_struct_nostd_tests/src/lib.rs
+++ b/packed_struct_nostd_tests/src/lib.rs
@@ -62,7 +62,7 @@ mod tests {
             sensor_value: -1503
         };
 
-        let packed: [u8; 4] = reg.pack();
+        let packed: [u8; 4] = reg.pack().unwrap();
         assert_eq!([0x8B, 0xE7, 0x21, 0xFA], packed);
         let unpacked = ControlRegister::unpack(&[0x8B, 0xE7, 0x21, 0xFA]).unwrap();
         assert_eq!(unpacked, reg);

--- a/packed_struct_tests/tests/debug_fields.rs
+++ b/packed_struct_tests/tests/debug_fields.rs
@@ -4,20 +4,21 @@ extern crate packed_struct_codegen;
 
 use packed_struct::prelude::*;
 
+#[allow(non_camel_case_types)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PrimitiveEnum_u8)]	
 #[repr(u8)]
 pub enum DataRate {
     /// No output data is produced.
     PowerDown = 0,
-    Rate_3_125Hz = 1,
-    Rate_6_25Hz = 2,
-    Rate_12_5Hz = 3,
-    Rate_25Hz = 4,
-    Rate_50Hz = 5,
-    Rate_100Hz = 6,
-    Rate_400Hz = 7,
-    Rate_800Hz = 8,
-    Rate_1600Hz = 9
+    Rate3_125Hz = 1,
+    Rate6_25Hz = 2,
+    Rate12_5Hz = 3,
+    Rate25Hz = 4,
+    Rate50Hz = 5,
+    Rate100Hz = 6,
+    Rate400Hz = 7,
+    Rate800Hz = 8,
+    Rate1600Hz = 9
 }
 
 // Imaginary register, for test purposes only
@@ -42,7 +43,7 @@ pub struct ControlRegister4 {
 #[test]
 fn test_debug_reg() {
     let r = ControlRegister4 {
-        output_data_rate: DataRate::Rate_6_25Hz,
+        output_data_rate: DataRate::Rate6_25Hz,
         x_axis_enabled: false,
         y_axis_enabled: false,
         z_axis_enabled: true        

--- a/packed_struct_tests/tests/enum_packing.rs
+++ b/packed_struct_tests/tests/enum_packing.rs
@@ -31,7 +31,7 @@ fn prim() {
         enabled: true
     };
 
-    let packed = test.pack();
+    let packed = test.pack().unwrap();
     assert_eq!([0b00110010], packed);
 
     let unpacked = TestPack::unpack(&packed).unwrap();

--- a/packed_struct_tests/tests/enum_packing_2.rs
+++ b/packed_struct_tests/tests/enum_packing_2.rs
@@ -4,20 +4,21 @@ extern crate packed_struct_codegen;
 
 use packed_struct::prelude::*;
 
+#[allow(non_camel_case_types)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PrimitiveEnum_u8)]	
 #[repr(u8)]
 pub enum DataRate {
     /// No output data is produced.
     PowerDown = 0,
-    Rate_3_125Hz = 1,
-    Rate_6_25Hz = 2,
-    Rate_12_5Hz = 3,
-    Rate_25Hz = 4,
-    Rate_50Hz = 5,
-    Rate_100Hz = 6,
-    Rate_400Hz = 7,
-    Rate_800Hz = 8,
-    Rate_1600Hz = 9
+    Rate3_125Hz = 1,
+    Rate6_25Hz = 2,
+    Rate12_5Hz = 3,
+    Rate25Hz = 4,
+    Rate50Hz = 5,
+    Rate100Hz = 6,
+    Rate400Hz = 7,
+    Rate800Hz = 8,
+    Rate1600Hz = 9
 }
 
 // Imaginary register, for test purposes only
@@ -36,10 +37,10 @@ pub struct ControlRegister4 {
 #[test]
 fn test_reg() {
     let r = ControlRegister4 {
-        output_data_rate: DataRate::Rate_6_25Hz,
+        output_data_rate: DataRate::Rate6_25Hz,
         z_axis_enabled: true
     };
 
-    let b = r.pack();
+    let b = r.pack().unwrap();
     assert_eq!([0b00010010], b);
 }

--- a/packed_struct_tests/tests/enum_packing_3.rs
+++ b/packed_struct_tests/tests/enum_packing_3.rs
@@ -41,7 +41,7 @@ fn enum_packing_3() {
         mode: SelfTestMode::DebugMode,
     };
 
-    let packed = test.pack();
+    let packed = test.pack().unwrap();
     let unpacked = TestPack::unpack(&packed).unwrap();
     assert_eq!(&test, &unpacked);
 
@@ -49,6 +49,6 @@ fn enum_packing_3() {
     let m = TestPackMode {
         mode: a
     };
-    let p = m.pack();
+    let p = m.pack().unwrap();
     assert_eq!(&[3], &p);
 }

--- a/packed_struct_tests/tests/packing_arrays.rs
+++ b/packed_struct_tests/tests/packing_arrays.rs
@@ -18,7 +18,7 @@ fn test_packed_arrays() {
         arr1: [1, 2, 3, 4, 5, 6, 7]
     };
 
-    let packed = a.pack();
+    let packed = a.pack().unwrap();
     assert_eq!(&packed, &[1, 2, 3, 4, 5, 6, 7]);
     
     let unpacked = Arrays::unpack(&packed).unwrap();
@@ -51,7 +51,7 @@ fn test_packed_array_of_structs() {
         ]
     };
 
-    let packed: [u8; 4*6] = p.pack();
+    let packed: [u8; 4*6] = p.pack().unwrap();
 
     let unpacked = Packaged::unpack(&packed).unwrap();
     assert_eq!(&p, &unpacked);

--- a/packed_struct_tests/tests/packing_autosize.rs
+++ b/packed_struct_tests/tests/packing_autosize.rs
@@ -21,7 +21,7 @@ fn test_serialization_autosize_msb0() {
             bool2: true
         };
 
-    let packed = b.pack();
+    let packed = b.pack().unwrap();
     assert_eq!(&packed, &[0b10000000, 0b10000000]);
 
     let unpacked = Bools::unpack(&packed).unwrap();
@@ -45,7 +45,7 @@ fn test_serialization_autosize_lsb0() {
             bool2: true
         };
 
-    let packed = b.pack();
+    let packed = b.pack().unwrap();
     assert_eq!(&packed, &[0b10000000, 0b10000000]);
 
     let unpacked = Bools::unpack(&packed).unwrap();

--- a/packed_struct_tests/tests/packing_bit_positioning.rs
+++ b/packed_struct_tests/tests/packing_bit_positioning.rs
@@ -28,7 +28,7 @@ fn test_packing_bit_positions() {
         val5: true
     };
 
-    let packed = a.pack();
+    let packed = a.pack().unwrap();
     assert_eq!([255], packed);
 
     let unpacked = SmallInts::unpack(&packed).unwrap();
@@ -52,7 +52,7 @@ fn test_packing_bit_positions_lsb() {
         val2: true
     };
 
-    let packed = a.pack();
+    let packed = a.pack().unwrap();
     assert_eq!(&[0b01000111], &packed);
 
     let unpacked = SmallIntsLsb::unpack(&packed).unwrap();
@@ -80,7 +80,7 @@ fn test_packing_byte_position() {
         checksum: 869034217895
     };
     
-    let packed = b.pack();
+    let packed = b.pack().unwrap();
     assert_eq!(packed.len(), 13);
 
     let unpacked = BufferChecksum::unpack(&packed).unwrap();

--- a/packed_struct_tests/tests/packing_codegen_1.rs
+++ b/packed_struct_tests/tests/packing_codegen_1.rs
@@ -30,7 +30,7 @@ fn test_serialization_codegen() {
             bool3: true
         };
 
-    let packed = b.pack();
+    let packed = b.pack().unwrap();
     assert_eq!(&packed, &[0b10010100, 0b10101010, 0b10100000, 0b00000101]);
 
     let unpacked = Bools::unpack(&packed).unwrap();

--- a/packed_struct_tests/tests/packing_codegen_2.rs
+++ b/packed_struct_tests/tests/packing_codegen_2.rs
@@ -28,7 +28,7 @@ fn test_packed_struct_u8() {
         low_power: true
     };
 
-    let packed = reg.pack();
+    let packed = reg.pack().unwrap();
     assert_eq!(&[0b01010100], &packed);
 }
 
@@ -55,7 +55,7 @@ fn test_packed_struct_range() {
             num2: 0b1101010111010101
         };
 
-        let packed = i.pack();
+        let packed = i.pack().unwrap();
         assert_eq!(&packed, &[0b00111010, 0b10101010, 0b10111010, 0b10111010, 0b10100000, 0]);
     }
 }    

--- a/packed_struct_tests/tests/packing_compact_byte.rs
+++ b/packed_struct_tests/tests/packing_compact_byte.rs
@@ -25,7 +25,7 @@ fn test_packed_compact_byte() {
         field_c: 0b010.into()
     };
 
-    let packed = reg.pack();
+    let packed = reg.pack().unwrap();
     assert_eq!(&packed, &[0b10111010]);
 
     let unpacked = RegA::unpack(&packed).unwrap();

--- a/packed_struct_tests/tests/packing_enum_16bit.rs
+++ b/packed_struct_tests/tests/packing_enum_16bit.rs
@@ -24,7 +24,7 @@ fn prim() {
         large: LargeEnum::Value1024
     };
 
-    let packed = st.pack();
+    let packed = st.pack().unwrap();
     assert_eq!([0b0000_0100, 0b0000_0000], packed);
 
     let unpacked = StructWithBitsEnum::unpack(&packed).unwrap();

--- a/packed_struct_tests/tests/packing_lsb_bit_order.rs
+++ b/packed_struct_tests/tests/packing_lsb_bit_order.rs
@@ -22,7 +22,7 @@ fn test_pos() {
         num2: 28.into()
     };
 
-    let packed = s.pack();
+    let packed = s.pack().unwrap();
     let unpacked = IntsLsbPosBits::unpack(&packed).unwrap();
 
     assert_eq!(unpacked, s);

--- a/packed_struct_tests/tests/packing_msp.rs
+++ b/packed_struct_tests/tests/packing_msp.rs
@@ -20,7 +20,7 @@ fn test_packed_struct_msp() {
         i2c_errors: 1
     };
 
-    let packed = reg.pack();
+    let packed = reg.pack().unwrap();
     assert_eq!(&packed, &[0xBB, 0xAA, 0x01, 0x00]);
 
     let unpacked = MspStatus::unpack(&packed).unwrap();

--- a/packed_struct_tests/tests/packing_primitives.rs
+++ b/packed_struct_tests/tests/packing_primitives.rs
@@ -25,7 +25,7 @@ fn test_packed_primitives() {
         num2: 0b0101010111010101
     };
 
-    let packed = i.pack();
+    let packed = i.pack().unwrap();
     assert_eq!(&packed, &[0b00101010, 0b10101010, 0b10111010, 0b10101010, 0b10100000, 0]);
 }
 
@@ -53,7 +53,7 @@ fn test_packed_int_msb_endian() {
         ..Default::default()
     };
 
-    let packed = i.pack();
+    let packed = i.pack().unwrap();
     let unpacked = IntsMsb::unpack(&packed).unwrap();
     assert_eq!(i, unpacked);
 }
@@ -82,7 +82,7 @@ fn test_packed_int_lsb_endian() {
         ..Default::default()
     };
 
-    let packed = i.pack();
+    let packed = i.pack().unwrap();
     let unpacked = IntsLsb::unpack(&packed).unwrap();
     assert_eq!(i, unpacked);
 }

--- a/packed_struct_tests/tests/packing_reserved.rs
+++ b/packed_struct_tests/tests/packing_reserved.rs
@@ -19,7 +19,7 @@ pub struct StructOne {
 #[cfg(test)]
 fn test_packed_reserved_fields() {
     let s = StructOne::default();
-    let packed = s.pack();
+    let packed = s.pack().unwrap();
     assert_eq!([0b0000_0_111], packed);
 
     let unpacked = StructOne::unpack(&[0b1111_1_000]).unwrap();

--- a/packed_struct_tests/tests/packing_tiny_flags.rs
+++ b/packed_struct_tests/tests/packing_tiny_flags.rs
@@ -22,7 +22,7 @@ fn test_tiny_flags() {
         flag2: false
     };
 
-    let packed = flag.pack();
+    let packed = flag.pack().unwrap();
     assert_eq!([0b00001110], packed);
     let unpacked = TinyFlags::unpack(&packed).unwrap();
     assert_eq!(unpacked, flag);
@@ -43,7 +43,7 @@ fn test_tiny_flags() {
         ]
     };
 
-    let packed = example.pack();
+    let packed = example.pack().unwrap();
     let unpacked = Settings::unpack(&packed).unwrap();
 
     assert_eq!(example, unpacked);

--- a/packed_struct_tests/tests/primitive_enum_catch_all.rs
+++ b/packed_struct_tests/tests/primitive_enum_catch_all.rs
@@ -27,14 +27,14 @@ fn prim_catch_all() {
     let r = Register {
         field: Field::B.into()
     };
-    let packed = r.pack();
+    let packed = r.pack().unwrap();
     assert_eq!([0b0010_0000], packed);
     assert_eq!(2, r.field.to_primitive());
 
     let packed_unknown_value = [0b0100_0000];
     let unpacked_unknown_value = Register::unpack(&packed_unknown_value).unwrap();
     assert_eq!(0b0100, unpacked_unknown_value.field.to_primitive());
-    let repacked = unpacked_unknown_value.pack();
+    let repacked = unpacked_unknown_value.pack().unwrap();
     assert_eq!([0b0100_0000], repacked);
 
     println!("unknown: {:#?}", unpacked_unknown_value);

--- a/packed_struct_tests/tests/roundtrip_1.rs
+++ b/packed_struct_tests/tests/roundtrip_1.rs
@@ -78,7 +78,7 @@ fn test_roundtrip_1() {
             f15: if (rnd.next() % 2) == 0 { true } else { false }
         };
 
-        let packed = s.pack();
+        let packed = s.pack().unwrap();
 
         let unpacked = RoundtripAligned::unpack(&packed).unwrap();
         assert_eq!(&s, &unpacked);

--- a/packed_struct_tests/tests/roundtrip_2.rs
+++ b/packed_struct_tests/tests/roundtrip_2.rs
@@ -73,7 +73,7 @@ fn test_roundtrip_2() {
             f15: if (rnd.next() % 2) == 0 { true } else { false }
         };
 
-        let packed = s.pack();
+        let packed = s.pack().unwrap();
 
         let unpacked = RoundtripUnaligned::unpack(&packed).unwrap();
         assert_eq!(&s, &unpacked);

--- a/packed_struct_tests/tests/test_usb_pd.rs
+++ b/packed_struct_tests/tests/test_usb_pd.rs
@@ -38,7 +38,7 @@ fn test_serialization_codegen() {
     p.voltage = 0b10_11111111.into();
     p.maximum_current = 0b10_10101010.into();
         
-    let packed = p.pack();
+    let packed = p.pack().unwrap();
     assert_eq!([0b00000010, 0b0000_1011, 0b111111_10, 0b10101010], packed);
 
     let unpacked = PowerDataObjectFixed::unpack(&packed).unwrap();

--- a/packed_struct_tests/tests/test_wide_ints_14.rs
+++ b/packed_struct_tests/tests/test_wide_ints_14.rs
@@ -19,7 +19,7 @@ macro_rules! test_int_14 {
             let roundtrip = |x: u16| {
                 let mut t: Test = Default::default();
                 t.int1 = x.into();
-                let packed = t.pack();
+                let packed = t.pack().unwrap();
 
                 let unpacked = Test::unpack(&packed).unwrap();
                 assert_eq!(unpacked, t);

--- a/packed_struct_tests/tests/test_wide_ints_50.rs
+++ b/packed_struct_tests/tests/test_wide_ints_50.rs
@@ -19,7 +19,7 @@ macro_rules! test_int_50 {
             let roundtrip = |x: u64| {
                 let mut t: Test = Default::default();
                 t.int1 = x.into();
-                let packed = t.pack();
+                let packed = t.pack().unwrap();
 
                 let unpacked = Test::unpack(&packed).unwrap();
                 assert_eq!(unpacked, t);


### PR DESCRIPTION
Prohibit `src[0..5]` pattern as they might trigger a `panic`.

Note: this has been applied sparingly to most functions that operate on user-supplied slices. Full application to arrays will have to wait a bit, maybe with const generics.