### PR TITLE
Revert back by default to generating up to 32 byte arrays

### DIFF
--- a/packed_struct/Cargo.toml
+++ b/packed_struct/Cargo.toml
@@ -23,6 +23,8 @@ default-features = false
 default = ["std"]
 std = ["serde/std"]
 alloc = []
+byte_types_64 = []
+byte_types_256 = []
 
 # comment this section when publishing new releases to crates.io!
 [dev-dependencies]

--- a/packed_struct/build.rs
+++ b/packed_struct/build.rs
@@ -12,7 +12,14 @@ fn main() {
     let dest_path = Path::new(&out_dir).join("generate_bytes_and_bits.rs");
     let mut f = File::create(&dest_path).unwrap();
 
-    let up_to_bytes = 256;
+    let up_to_bytes = 
+        if cfg!(feature = "byte_types_256") {
+            256
+        } else if cfg!(feature = "byte_types_64") {
+            64
+        } else {
+            32
+        };
 
     // bytes
     for i in 0..(up_to_bytes + 1) {

--- a/packed_struct_tests/Cargo.toml
+++ b/packed_struct_tests/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Rudi Benkovic <rudi.benkovic@gmail.com>"]
 publish = false
 
 [dependencies]
-packed_struct = "0.4"
+packed_struct = { version = "0.4", features = ["byte_types_64"] }
 packed_struct_codegen = "0.4"
 error-chain = "0.12.0"


### PR DESCRIPTION
The 256 build is slow. Added features for 64 and 256 byte generators.

Awaiting const generics.