### PR TITLE
Primitive Enums roundtrip tests and fixes

### DIFF
--- a/packed_struct_codegen/src/primitive_enum.rs
+++ b/packed_struct_codegen/src/primitive_enum.rs
@@ -230,7 +230,7 @@ fn get_unitary_enum(input: &syn::DeriveInput) -> syn::Result<Vec<Variant>> {
 
     let mut r = Vec::new();
 
-    let mut d = 0;
+    let mut d: Option<u64> = None;
     let mut neg = false;
 
     for variant in &data_enum.variants {
@@ -265,10 +265,15 @@ fn get_unitary_enum(input: &syn::DeriveInput) -> syn::Result<Vec<Variant>> {
                 return Err(syn::Error::new(variant.span(), "Unsupported enum const expr"));
             },
             None => {
-                if neg {
-                    (d-1, if d-1 == 0 { false } else { true }, "".into())
-                } else {
-                    (d+1, false, "".into())
+                match d {
+                    None => (0, false, "".into()),
+                    Some(d) => {
+                        if neg {
+                            (d-1, if d-1 == 0 { false } else { true }, "".into())
+                        } else {
+                            (d+1, false, "".into())
+                        }
+                    }
                 }
             }
         };
@@ -280,7 +285,7 @@ fn get_unitary_enum(input: &syn::DeriveInput) -> syn::Result<Vec<Variant>> {
             suffix
         });
 
-        d = discriminant;                
+        d = Some(discriminant);
         neg = negative;                
     }
     

--- a/packed_struct_tests/tests/primitive_enum_roundtrip.rs
+++ b/packed_struct_tests/tests/primitive_enum_roundtrip.rs
@@ -1,0 +1,55 @@
+use packed_struct::{PrimitiveEnumStaticStr, prelude::*};
+
+#[derive(PrimitiveEnum_u8, Clone, Copy, Debug, PartialEq)]
+pub enum EnumImplicit {
+    Zero,
+    One,
+    Two,
+    Three
+}
+
+#[derive(PrimitiveEnum_u8, Clone, Copy, Debug, PartialEq)]
+pub enum EnumExplicit {
+    Zero = 0,
+    One,
+    Two,
+    Three
+}
+
+#[derive(PrimitiveEnum_u8, Clone, Copy, Debug, PartialEq)]
+pub enum EnumExplicitHalf {
+    Zero,
+    One = 1,
+    Two,
+    Three
+}
+
+#[derive(PrimitiveEnum_u8, Clone, Copy, Debug, PartialEq)]
+pub enum EnumExplicitFull {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Three = 3
+}
+
+#[test]
+fn prim() {
+    test_enum::<EnumImplicit>();
+    test_enum::<EnumExplicit>();
+    test_enum::<EnumExplicitHalf>();
+    test_enum::<EnumExplicitFull>();
+}
+
+fn test_enum<E: PrimitiveEnum<Primitive = u8> + PrimitiveEnumStaticStr + std::fmt::Debug + PartialEq + 'static>() {
+    for (i, x) in E::all_variants().iter().enumerate() {
+        let prim = x.to_primitive();
+        assert_eq!(prim, i as u8);
+
+        let from_prim = E::from_primitive(prim).unwrap();
+        assert_eq!(from_prim, *x);
+
+        let display_str = x.to_display_str();
+        let from_display_str = E::from_str(display_str).unwrap();
+        assert_eq!(from_display_str, *x);
+    }
+}

--- a/packed_struct_tests/tests/primitive_enum_roundtrip.rs
+++ b/packed_struct_tests/tests/primitive_enum_roundtrip.rs
@@ -1,3 +1,5 @@
+use std::any::type_name;
+
 use packed_struct::{PrimitiveEnumStaticStr, prelude::*};
 
 #[derive(PrimitiveEnum_u8, Clone, Copy, Debug, PartialEq)]
@@ -25,6 +27,14 @@ pub enum EnumExplicitHalf {
 }
 
 #[derive(PrimitiveEnum_u8, Clone, Copy, Debug, PartialEq)]
+pub enum EnumExplicitHalfZero {
+    Zero = 0,
+    One,
+    Two = 2,
+    Three
+}
+
+#[derive(PrimitiveEnum_u8, Clone, Copy, Debug, PartialEq)]
 pub enum EnumExplicitFull {
     Zero = 0,
     One = 1,
@@ -32,24 +42,68 @@ pub enum EnumExplicitFull {
     Three = 3
 }
 
-#[test]
-fn prim() {
-    test_enum::<EnumImplicit>();
-    test_enum::<EnumExplicit>();
-    test_enum::<EnumExplicitHalf>();
-    test_enum::<EnumExplicitFull>();
+#[derive(PrimitiveEnum_i8, Clone, Copy, Debug, PartialEq)]
+pub enum EnumExplicitNegative {
+    MinusTwo = -2,
+    MinusOne = -1,
+    Zero,
+    One = 1,
+    Two = 2
 }
 
-fn test_enum<E: PrimitiveEnum<Primitive = u8> + PrimitiveEnumStaticStr + std::fmt::Debug + PartialEq + 'static>() {
+#[derive(PrimitiveEnum_i8, Clone, Copy, Debug, PartialEq)]
+pub enum EnumExplicitNegativeOne {
+    MinusOne = -1,
+    Zero,
+    One,
+    Two
+}
+
+
+#[derive(PrimitiveEnum_i8, Clone, Copy, Debug, PartialEq)]
+pub enum EnumExplicitNegativeTwo {
+    MinusTwo = -2,
+    MinusOne,
+    Zero,
+    One,
+    Two
+}
+
+#[test]
+fn prim() {
+    test_enum_positive::<EnumImplicit>();
+    test_enum_positive::<EnumExplicit>();
+    test_enum_positive::<EnumExplicitHalf>();
+    test_enum_positive::<EnumExplicitHalfZero>();
+
+    test_enum_negative::<EnumExplicitNegative>();
+    test_enum_negative::<EnumExplicitNegativeOne>();
+    test_enum_negative::<EnumExplicitNegativeTwo>();
+}
+
+fn test_enum_positive<E: PrimitiveEnum<Primitive = u8> + PrimitiveEnumStaticStr + std::fmt::Debug + PartialEq + 'static>() {
     for (i, x) in E::all_variants().iter().enumerate() {
         let prim = x.to_primitive();
         assert_eq!(prim, i as u8);
 
-        let from_prim = E::from_primitive(prim).unwrap();
+        let from_prim = E::from_primitive(prim).expect(&format!("Expected a successful parse of {}, ty {}", prim, type_name::<E>()));
         assert_eq!(from_prim, *x);
 
         let display_str = x.to_display_str();
-        let from_display_str = E::from_str(display_str).unwrap();
+        let from_display_str = E::from_str(display_str).expect(&format!("Expected a successful parse of display string {}, ty {}", display_str, type_name::<E>()));
+        assert_eq!(from_display_str, *x);
+    }
+}
+
+fn test_enum_negative<E: PrimitiveEnum<Primitive = i8> + PrimitiveEnumStaticStr + std::fmt::Debug + PartialEq + 'static>() {
+    for x in E::all_variants().iter() {
+        let prim = x.to_primitive();
+
+        let from_prim = E::from_primitive(prim).expect(&format!("Expected a successful parse of {}, ty {}", prim, type_name::<E>()));
+        assert_eq!(from_prim, *x);
+
+        let display_str = x.to_display_str();
+        let from_display_str = E::from_str(display_str).expect(&format!("Expected a successful parse of display string {}, ty {}", display_str, type_name::<E>()));
         assert_eq!(from_display_str, *x);
     }
 }


### PR DESCRIPTION
Fixes the case where the first discriminant value was incorrect. Added tests for negative and positive cases.