### PR TITLE
Fix for rustc compiler warning: unused borrow that must be used

### DIFF
--- a/packed_struct/src/types_generic.rs
+++ b/packed_struct/src/types_generic.rs
@@ -7,7 +7,7 @@ impl<T> PackedStructSlice for T where T: PackedStruct, T::ByteArray : ByteArray 
             return Err(PackingError::BufferSizeMismatch { expected: <T::ByteArray as ByteArray>::len(), actual: output.len() });
         }
         let packed = self.pack()?;
-        &mut output[..].copy_from_slice(&packed.as_bytes_slice());
+        output[..].copy_from_slice(&packed.as_bytes_slice());
         Ok(())
     }
 

--- a/packed_struct_codegen/src/pack_codegen.rs
+++ b/packed_struct_codegen/src/pack_codegen.rs
@@ -162,11 +162,11 @@ fn pack_bits(field: &FieldRegular) -> PackBitsCopy {
         
         PackBitsCopy {
             pack: quote! {
-                &mut target[#start..#end].copy_from_slice(&packed);
+                target[#start..#end].copy_from_slice(&packed);
             },
             unpack: quote! {
                 let mut b = [0; (#end - #start)];
-                &mut b[..].copy_from_slice(&src[#start..#end]);
+                b[..].copy_from_slice(&src[#start..#end]);
                 b
             }
         }


### PR DESCRIPTION
Fixes #77 

```
warning: unused borrow that must be used
 --> src/main.rs:6:5
  |
6 |     &mut b[..].copy_from_slice(&src[..]);
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the borrow produces a value
  |
  = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
  |
6 |     let _ = &mut b[..].copy_from_slice(&src[..]);
  |     +++++++
```