### PR TITLE
Update bitvec dependency

### DIFF
--- a/packed_struct/Cargo.toml
+++ b/packed_struct/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 packed_struct_codegen = { path = "../packed_struct_codegen/", version = "0.10.1" }
 serde = { version = "1.0", optional = true, default-features = false }
 serde_derive = { version = "1.0", optional = true }
-bitvec = { version = "0.22.3", default-features = false }
+bitvec = { version = "1.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/packed_struct/src/types_num.rs
+++ b/packed_struct/src/types_num.rs
@@ -669,7 +669,7 @@ impl<T, B, I> PackedStruct for LsbInteger<T, B, I>
             let leftover_bits = B::number_of_bits() % 8;            
             
             let bytes_slice = bytes.as_mut_bytes_slice();
-            let bits = BitSlice::<Msb0, _>::from_slice_mut(bytes_slice).map_err(|_| PackingError::BitsError)?;
+            let bits = BitSlice::<_, Msb0>::try_from_slice_mut(bytes_slice).map_err(|_| PackingError::BitsError)?;
             let s = l - B::number_of_bits();
             let (left, _) = bits.split_at_mut(l - leftover_bits);
             left.shift_right(s);
@@ -690,7 +690,7 @@ impl<T, B, I> PackedStruct for LsbInteger<T, B, I>
 
             let mut src_bytes = (*src).clone();
             let bytes_slice = src_bytes.as_mut_bytes_slice();
-            let bits = BitSlice::<Msb0, _>::from_slice_mut(bytes_slice).map_err(|_| PackingError::BitsError)?;
+            let bits = BitSlice::<_, Msb0>::try_from_slice_mut(bytes_slice).map_err(|_| PackingError::BitsError)?;
             let s = l - B::number_of_bits();
             let (left, _) = bits.split_at_mut(l - leftover_bits);
             left.shift_left(s);


### PR DESCRIPTION
`bitvec` 0.22 depends on a version of `funty` which has been yanked. This commit updates the `bitvec` dependency to a newer version.
```
error: failed to select a version for the requirement `funty = "~1.2"`
candidate versions found which didn't match: 2.0.0, 1.1.0, 1.0.1, ...
location searched: crates.io index
required by package `bitvec v0.22.3`
    ... which satisfies dependency `bitvec = "^0.22.3"` of package `packed_struct v0.10.1
```
Any crate using `packed_struct` currently will not build, so a new minor release would probably also be required.