### PR TITLE
Import formatter for alloc but no_std environments

### DIFF
--- a/packed_struct/src/debug_fmt.rs
+++ b/packed_struct/src/debug_fmt.rs
@@ -2,7 +2,13 @@
 
 use crate::internal_prelude::v1::*;
 
-#[cfg(any(feature="alloc", feature="std"))]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+use alloc::fmt::Formatter;
+
+#[cfg(feature = "std")]
+use std::fmt::Formatter;
+
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub trait PackedStructDebug {
     fn fmt_fields(&self, fmt: &mut Formatter) -> Result<(), FmtError>;
     fn packed_struct_display_header() -> &'static str;


### PR DESCRIPTION
Right now, if you have alloc but no_std, packed_struct will not compile
because it does not import the Formatter type.

This imports the std one for std, no_alloc, and the alloc
one for alloc, no_std.
