### PR TITLE
implemented the fmt::Binary trait on Integer

### DIFF
--- a/packed_struct/src/types_num.rs
+++ b/packed_struct/src/types_num.rs
@@ -36,6 +36,12 @@ impl<T, B> Display for Integer<T, B> where T: Display {
     }
 }
 
+impl<T, B> fmt::Binary for Integer<T, B> where T: fmt::Binary {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.num.fmt(f)
+    }
+}
+
 #[cfg(feature = "use_serde")]
 mod serialize {
     use serde::ser::{Serialize, Serializer};


### PR DESCRIPTION
The Integer struct could implement the binary trait to allow usage of the `{:b}` formatter.

The implementation is fairly trivial, and similar to the implementations of the Debug and Display traits.