### PR TITLE
Adds header and footer attributes and traits

### DIFF
--- a/packed_struct/src/packing.rs
+++ b/packed_struct/src/packing.rs
@@ -24,9 +24,9 @@ pub trait PackedStructHeader where Self: PackedStruct + Sized {
     type HeaderByteArray : ByteArray;
     
     /// Returns the header data to attach it to the front of the packed data
-    fn get_data(&self, data: &[u8]) -> PackingResult<Self::HeaderByteArray>;
+    fn get_header(&self, data: &[u8]) -> PackingResult<Self::HeaderByteArray>;
     /// Validates the structure/footer from a byte array when unpacking.
-    fn validate_data(_src: &[u8]) -> PackingResult<()> {
+    fn validate_header(_src: &[u8]) -> PackingResult<()> {
         Ok(())
     }
 }
@@ -36,9 +36,9 @@ pub trait PackedStructFooter where Self: PackedStruct + Sized {
     type FooterByteArray : ByteArray;
     
     /// Returns the footer data to attach it to the end of the packed data
-    fn get_data(&self, data: &[u8]) -> PackingResult<Self::FooterByteArray>;
+    fn get_footer(&self, data: &[u8]) -> PackingResult<Self::FooterByteArray>;
     /// Validates the structure/footer from a byte array when unpacking.
-    fn validate_data(_src: &[u8]) -> PackingResult<()> {
+    fn validate_footer(_src: &[u8]) -> PackingResult<()> {
         Ok(())
     }
 }

--- a/packed_struct/src/packing.rs
+++ b/packed_struct/src/packing.rs
@@ -104,7 +104,7 @@ impl ::std::error::Error for PackingError {
             PackingError::SliceIndexingError { .. } => "Failed to index into a slice",
             PackingError::MoreThanOneDynamicType => "Only one dynamically sized type is supported in the tuple",
             PackingError::InternalError => "Internal error",
-            PackingError::UserError(err) => &err
+            PackingError::UserError(err) => err
         }
     }
 }

--- a/packed_struct/src/packing.rs
+++ b/packed_struct/src/packing.rs
@@ -81,6 +81,7 @@ pub enum PackingError {
     BufferModMismatch { actual_size: usize, modulo_required: usize },
     SliceIndexingError { slice_len: usize },
     InternalError,
+    #[cfg(feature = "std")]
     UserError(String)
 }
 
@@ -104,6 +105,7 @@ impl ::std::error::Error for PackingError {
             PackingError::SliceIndexingError { .. } => "Failed to index into a slice",
             PackingError::MoreThanOneDynamicType => "Only one dynamically sized type is supported in the tuple",
             PackingError::InternalError => "Internal error",
+            #[cfg(feature = "std")]
             PackingError::UserError(err) => err
         }
     }

--- a/packed_struct_codegen/src/pack.rs
+++ b/packed_struct_codegen/src/pack.rs
@@ -50,7 +50,8 @@ pub struct PackStruct<'a> {
     pub num_bits: usize,
     pub data_struct: &'a syn::DataStruct,
     pub derive_input: &'a syn::DeriveInput,
-    pub prepend: Option<Prepend>,
+    pub header: Option<Header>,
+    pub footer: Option<Footer>,
 }
 
 

--- a/packed_struct_codegen/src/pack.rs
+++ b/packed_struct_codegen/src/pack.rs
@@ -49,7 +49,8 @@ pub struct PackStruct<'a> {
     pub num_bytes: usize,
     pub num_bits: usize,
     pub data_struct: &'a syn::DataStruct,
-    pub derive_input: &'a syn::DeriveInput
+    pub derive_input: &'a syn::DeriveInput,
+    pub prepend: Option<Prepend>,
 }
 
 

--- a/packed_struct_codegen/src/pack_codegen.rs
+++ b/packed_struct_codegen/src/pack_codegen.rs
@@ -36,7 +36,7 @@ pub fn derive_pack(parsed: &PackStruct) -> syn::Result<proc_macro2::TokenStream>
                 header_offset = *size;
                 header_trait_token_get_data = quote! {
                     {
-                        let bytes = Self::get_data(&self, &target)?;
+                        let bytes = Self::get_header(&self, &target)?;
                         assert!(#num_bytes >= bytes.len(), "Packed bytes array is smaller than header array even though we added the header length!"); 
                         assert!(#size == bytes.len(), "Header size set with attribute is not equal to header array size returned by PackedStructHeader trait!"); 
                         target[0..bytes.len()].copy_from_slice(&bytes);
@@ -44,7 +44,7 @@ pub fn derive_pack(parsed: &PackStruct) -> syn::Result<proc_macro2::TokenStream>
                 };
                 header_trait_token_validate = quote! {
                     {
-                        Self::validate_data(src)?;
+                        Self::validate_header(src)?;
                     }
                 };
             },
@@ -72,7 +72,7 @@ pub fn derive_pack(parsed: &PackStruct) -> syn::Result<proc_macro2::TokenStream>
                 let footer_offset = num_bytes - *size;
                 footer_trait_token_get_data = quote! {
                     {
-                        let bytes = Self::get_data(&self, &target)?;
+                        let bytes = Self::get_footer(&self, &target)?;
                         assert!(#num_bytes >= bytes.len(), "Packed bytes array is smaller than footer array even though we added the footer length!"); 
                         assert!(#size == bytes.len(), "Footer size set with attribute is not equal to footer array size returned by PackedStructFooter trait!"); 
                         target[#footer_offset..].copy_from_slice(&bytes);
@@ -80,7 +80,7 @@ pub fn derive_pack(parsed: &PackStruct) -> syn::Result<proc_macro2::TokenStream>
                 };
                 footer_trait_token_validate = quote! {
                     {
-                        Self::validate_data(src)?;
+                        Self::validate_footer(src)?;
                     }
                 };
             },

--- a/packed_struct_codegen/src/pack_parse_attributes.rs
+++ b/packed_struct_codegen/src/pack_parse_attributes.rs
@@ -6,8 +6,10 @@ pub enum PackStructAttributeKind {
     //SizeBits,
     DefaultIntEndianness,
     BitNumbering,
-    Prepend,
-    Append,
+    Header,
+    HeaderWithTrait,
+    Footer,
+    FooterWithTrait,
 }
 
 impl PackStructAttributeKind {
@@ -19,8 +21,10 @@ impl PackStructAttributeKind {
             //SizeBits => "size_bits",
             DefaultIntEndianness => "endian",
             BitNumbering => "bit_numbering",
-            Prepend => "prepend",
-            Append => "append"
+            Header => "header",
+            HeaderWithTrait => "header_size",
+            Footer => "footer",
+            FooterWithTrait => "footer_size"
         }
     }
 }
@@ -30,8 +34,8 @@ pub enum PackStructAttribute {
     //SizeBits(usize),
     DefaultIntEndianness(IntegerEndianness),
     BitNumbering(BitNumbering),
-    Prepend(Prepend),
-    // Append(F, usize),
+    Header(Header),
+    Footer(Footer),
 }
 
 impl PackStructAttribute {
@@ -52,9 +56,24 @@ impl PackStructAttribute {
             return Ok(PackStructAttribute::SizeBytes(b));
         }
 
-        if name == PackStructAttributeKind::Prepend.get_attr_name() {
-            let b = Prepend::from_expr(val).expect("Invalid prepend value");
-            return Ok(PackStructAttribute::Prepend(b));
+        if name == PackStructAttributeKind::Header.get_attr_name() {
+            let b = Header::from_expr(val).expect("Invalid prepend value");
+            return Ok(PackStructAttribute::Header(b));
+        }
+
+        if name == PackStructAttributeKind::Footer.get_attr_name() {
+            let b = Footer::from_expr(val).expect("Invalid append value");
+            return Ok(PackStructAttribute::Footer(b));
+        }
+
+        if name == PackStructAttributeKind::HeaderWithTrait.get_attr_name() {
+            let b = Header::from_trait_expr(val).expect("Invalid prepend value");
+            return Ok(PackStructAttribute::Header(b));
+        }
+
+        if name == PackStructAttributeKind::FooterWithTrait.get_attr_name() {
+            let b = Footer::from_trait_expr(val).expect("Invalid append value");
+            return Ok(PackStructAttribute::Footer(b));
         }
 
         /*

--- a/packed_struct_examples/src/example2.rs
+++ b/packed_struct_examples/src/example2.rs
@@ -1,0 +1,129 @@
+//! Documentation example for the header and footer attributes and traits
+
+use packed_struct::{prelude::*, PackedStructHeader, PackedStructFooter};
+
+// Sometimes you want a static header or footer on a packed struckt. For example when you want to send the packed struct as a command via serial and you need the command to have a header
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", endian = "msb", header = [0x80, 0x60], footer = 0x16)]
+pub struct FunctionCommand {
+    #[packed_field(bytes = "0..=1")]
+    pub address: u16,
+    #[packed_field(bits = "16")]
+    pub f1: bool,
+    #[packed_field(bits = "17")]
+    pub f2: bool,
+    #[packed_field(bits = "18")]
+    pub f3: bool,
+    #[packed_field(bits = "19")]
+    pub f4: bool,
+    #[packed_field(bits = "20")]
+    pub f5: bool,
+    #[packed_field(bits = "21")]
+    pub f6: bool,
+    #[packed_field(bits = "22")]
+    pub f7: bool,
+    #[packed_field(bits = "23")]
+    pub f8: bool,
+}
+
+#[test]
+fn test_static_header_and_footer() {
+    let fun = FunctionCommand {
+        address: 1,
+        f1: true,
+        f2: false,
+        f3: true,
+        f4: false,
+        f5: false,
+        f6: true,
+        f7: false,
+        f8: true
+    };
+
+    let packed = fun.pack().unwrap();
+    assert_eq!(&packed, &[0x80 as u8, 0x60, 0x00, 0x01, 0b10100101, 0x16]);
+
+    let _unpacked = FunctionCommand::unpack(&[0x80 as u8, 0x60, 0x00, 0x01, 0b10100101, 0x00]).unwrap();
+
+    println!("{}", fun);
+}
+
+// Other times you might need to specify the header dynamically, for example if the header is different if all fields are false. You might also want to make sure your struct gets received correctly put an xor value in the footer
+#[derive(PackedStruct, Debug, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", endian = "msb", header_size = 1, footer_size = 1)]
+pub struct DynamicCommand {
+    #[packed_field(bits = "0")]
+    pub f1: bool,
+    #[packed_field(bits = "1")]
+    pub f2: bool,
+    #[packed_field(bits = "2")]
+    pub f3: bool,
+    #[packed_field(bits = "3")]
+    pub f4: bool,
+    #[packed_field(bits = "4")]
+    pub f5: bool,
+    #[packed_field(bits = "5")]
+    pub f6: bool,
+    #[packed_field(bits = "6")]
+    pub f7: bool,
+    #[packed_field(bits = "7")]
+    pub f8: bool,
+}
+
+impl PackedStructHeader for DynamicCommand {
+    type HeaderByteArray = [u8; 1];
+
+    fn get_header(&self, data: &[u8]) -> packed_struct::PackingResult<Self::HeaderByteArray> {
+        let header = if data[1] == 0 {
+            [0x00]
+        } else {
+            [0x80]
+        };
+        Ok(header)
+    }
+}
+
+impl PackedStructFooter for DynamicCommand {
+    type FooterByteArray = [u8; 1];
+
+    fn get_footer(&self, data: &[u8]) -> packed_struct::PackingResult<Self::FooterByteArray> {
+        // Note that the header is already part of the data at this point
+        let mut xor: u8 = 0;
+        data.into_iter().for_each(|value| xor ^= value);
+        Ok([xor])
+    }
+
+    fn validate_footer(src: &[u8]) -> packed_struct::PackingResult<()> {
+        let mut xor: u8 = 0;
+        src[0..src.len()].into_iter().for_each(|value| xor ^= value);
+        if src.ends_with(&[xor]) {
+            Ok(())
+        } else {
+            Err(PackingError::UserError(format!("Invalid xor: {} to {:?}", xor, src.last().unwrap())))
+        }
+    }
+}
+
+#[test]
+fn test_dynamic_header_and_footer() {
+    let dy = DynamicCommand {
+        f1: true,
+        f2: false,
+        f3: true,
+        f4: false,
+        f5: false,
+        f6: true,
+        f7: false,
+        f8: true
+    };
+
+    let packed = dy.pack().unwrap();
+    assert_eq!(&packed, &[0x80 as u8,0b10100101, 0x25]);
+
+    // We've set the footer to zero so it will fail to unpack
+    let unpacked_result = DynamicCommand::unpack(&[0x80 as u8, 0b10100101, 0x00]);
+
+    assert_eq!(unpacked_result, Err(PackingError::UserError("Invalid xor: 37 to 0".to_owned())));
+
+    println!("{}", dy);
+}

--- a/packed_struct_examples/src/lib.rs
+++ b/packed_struct_examples/src/lib.rs
@@ -4,6 +4,7 @@ extern crate packed_struct;
 use packed_struct::prelude::*;
 
 pub mod example1;
+pub mod example2;
 
 
 /// MultiWii status structure


### PR DESCRIPTION
Hello. I do quite like this library but had a need for some more features, so I wrote a PR for them.
This PR adds attributes and traits to add static or dynamic headers and footers to a packed struct.

For static values a header and/or footer can be specified with the `header` and `footer` attributes. They will be added on pack and will be ignored on unpack. No validation is happening on unpack for either field.
```rust
#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
#[packed_struct(bit_numbering = "msb0", endian = "msb", header = [0x80, 0x60], footer = 0x16)]
pub struct FunctionCommand {
```
This fixes https://github.com/hashmismatch/packed_struct.rs/issues/91

If a more dynamic value is needed for either header or footer I've added two traits, `PackedStructHeader` and `PackedStructFooter`. They each provide the `get_(header/footer)` and `validate_(header/footer)` methods, which receive the already packed structure and can be used to generate values and to validate them. Currently the size of the header or footer must be specified with an attribute (`(header/footer)_size = X`) because I could not find a way to get the size of the return value in the derive macro. The validation method gets called before the rest of the struct gets unpacked. I added a `PackingError::UserError` to allow users to easily return possible validation errors
```rust
#[derive(PackedStruct, Debug, Clone, PartialEq)]
#[packed_struct(bit_numbering = "msb0", endian = "msb", footer_size = 1)]
pub struct DynamicCommand {
    [...]
}

impl PackedStructFooter for DynamicCommand {
    type FooterByteArray = [u8; 1];

    fn get_footer(&self, data: &[u8]) -> packed_struct::PackingResult<Self::FooterByteArray> {
        let mut xor: u8 = 0;
        data.into_iter().for_each(|value| xor ^= value);
        Ok([xor])
    }

    fn validate_footer(src: &[u8]) -> packed_struct::PackingResult<()> {
        let mut xor: u8 = 0;
        // We don't want to xor the xor value at the end
        src[0..src.len()].into_iter().for_each(|value| xor ^= value);
        if src.ends_with(&[xor]) {
            Ok(())
        } else {
            Err(PackingError::UserError(format!("Invalid xor: {} to {:?}", xor, src.last().unwrap())))
        }
    }
}
```

I've also added tests/examples for the above. I'm currently also looking into allowing enums with structs inside to work with packed_struct as well by using `PackedStructHeader` but if I do this it'll be part of a separate PR